### PR TITLE
input component 생성

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,10 @@ module.exports = {
   rules: {
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     'react/react-in-jsx-scope': 'off', // jsx, tsx 파일에 import React from 'react'; 를 추가해야하는 규칙
-    'react/jsx-one-expression-per-line': 'off' // 정적 값과 동적 값을 같은 라인에서 사용하지 못하는 규칙
+    'react/jsx-one-expression-per-line': 'off', // 정적 값과 동적 값을 같은 라인에서 사용하지 못하는 규칙
+    'react/require-default-props': 'off', // props가 옵션일 때, default 값을 선언해야하는 규칙
+    'no-underscore-dangle': 'off', // underscore 변수 선언 못하게하는 규칙
+    '@typescript-eslint/naming-convention': 'off' // underscore 변수 선언 못하게하는 규칙
   },
   parserOptions: {
     project: ['./tsconfig.json'],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,31 @@
 import { useState } from 'react';
 import './App.css';
 import Button from './components/Button';
+import Input from './components/Input';
 
 function App() {
   const [count, setCount] = useState(0);
+  const [inputEmits, setInputEmits] = useState({ value: '', valid: false });
 
   function handleCount() {
     setCount(count + 1);
   }
 
+  function getInput(inputObject: { value: string; valid: boolean }) {
+    setInputEmits((prev) => ({
+      ...prev,
+      value: inputObject.value,
+      valid: inputObject.valid,
+    }));
+  }
+
   return (
     <div>
+      <div>value: {inputEmits.value}</div>
+      <div>valid: {String(inputEmits.valid)}</div>
+      <Input placeholder="플레이스홀더" regexp="ONLY_TEXT" getInputValue={(v) => getInput(v)} />
       <div>count: {count}</div>
-      <Button.Primary label="프라이머리" onClick={() => handleCount} disabled />
+      <Button.Primary label="프라이머리" onClick={() => handleCount} />
       <Button.Secondary label="프라이머리" onClick={() => handleCount} />
       <Button.Danger label="프라이머리" onClick={() => handleCount} />
     </div>

--- a/src/components/Input.module.scss
+++ b/src/components/Input.module.scss
@@ -1,0 +1,17 @@
+// TODO: style 포맷팅
+@mixin default {
+  border: 0;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+
+  &:disabled {
+    pointer-events: none;
+  }
+}
+
+// TODO: 반복문으로 변경
+.default {
+  @include default;
+}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,38 @@
+import style from './Input.module.scss';
+import React, { forwardRef } from 'react';
+
+interface InputProps {
+  placeholder: string;
+  default: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+interface LabelInputProps extends InputProps {
+  label: string,
+  name: string,
+  children: React.ReactNode
+}
+
+function LabelInput(props: LabelInputProps) {
+  const { label, children, name} = props;
+  return (
+    <div className="label-input">
+      <label htmlFor={name}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+const Input = forwardRef(function Input(props, ref) {
+  const { label, ...otherProps } = props;
+  return (
+    <label>
+      {label}
+      <input {...otherProps} />
+    </label>
+  );
+});
+
+
+export { LabelInput, Input };

--- a/src/constants/regexp.ts
+++ b/src/constants/regexp.ts
@@ -1,0 +1,8 @@
+const RegExp: Record<string, RegExp> = {
+  NONE: /''/g,
+  ONLY_TEXT: /[^ㄱ-ㅎ|가-힣|a-z|A-Z|]/g,
+  EMAIL: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+$/g,
+  PASSWORD: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/g,
+};
+
+export default RegExp;


### PR DESCRIPTION
# input 재사용 component 구현

**input의 value를 value를 받는 곳에서 직접 제어할 수 있는 제어 컴포넌트로 구현하였습니다.**

- 정규식을 props로 주어서 input에 입력할 수 있는 입력 값을 제어 가능합니다.
- input change에 대한 event를 useEffect로 상위 컴포넌트로 내보냅니다.

- 일부 eslint 규칙을 추가했습니다.

> 추후, 커스텀 정규식을 props로 넘길 수 있도록 디벨롭할 예정입니다.
> input의 상태 변화를 내보내는 함수는 debounce를 사용하여 성능 개선의 여지가 있습니다.